### PR TITLE
feat: Implements heartbeat and server status polling

### DIFF
--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -46,6 +46,11 @@ export const logsRoutes: FastifyPluginAsyncZod = async (app) => {
         })
       }
 
+      await db
+        .update(schema.servers)
+        .set({ lastPingAt: new Date() })
+        .where(eq(schema.servers.id, request.body.serverId))
+
       const point = new Point('system_metrics')
         .tag('serverId', serverId)
         .floatField('cpuUsage', cpuUsage)

--- a/apps/api/src/routes/server.ts
+++ b/apps/api/src/routes/server.ts
@@ -1,5 +1,6 @@
 import { REPL_MODE_STRICT } from 'node:repl'
 import { db, schema } from '@igris/database'
+import { desc, eq } from 'drizzle-orm'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 
@@ -71,13 +72,26 @@ export const serverRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request, reply) => {
       const rawServers = await db.select().from(schema.servers)
+      const formattedServers = rawServers.map((server) => {
+        let currentStatus = 'Offline'
 
-      const formattedServers = rawServers.map((server) => ({
-        id: server.id,
-        name: server.name,
-        ipAddress: server.ipAddress,
-        status: 'Ativo',
-      }))
+        if (server.lastPingAt) {
+          const now = new Date()
+          const pingTime = new Date(server.lastPingAt)
+          const diffInSeconds = (now.getTime() - pingTime.getTime()) / 1000
+
+          if (diffInSeconds <= 30) {
+            currentStatus = 'Ativo'
+          }
+        }
+
+        return {
+          id: server.id,
+          name: server.name,
+          ipAddress: server.ipAddress,
+          status: currentStatus,
+        }
+      })
 
       return reply.status(200).send(formattedServers)
     },

--- a/apps/web/src/components/ServerList.tsx
+++ b/apps/web/src/components/ServerList.tsx
@@ -12,16 +12,22 @@ export function ServerList() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetch('http://localhost:3333/servers')
-      .then((res) => res.json())
-      .then((data) => {
-        setServers(data)
-        setLoading(false)
-      })
-      .catch((err) => {
-        console.error('Erro ao buscar servidores: ', err)
-        setLoading(false)
-      })
+    const fetchServers = () => {
+      fetch('http://localhost:3333/servers')
+        .then((res) => res.json())
+        .then((data) => {
+          setServers(data)
+          setLoading(false)
+        })
+        .catch((err) => {
+          console.error('Erro ao buscar servidores:', err)
+          setLoading(false)
+        })
+    }
+    fetchServers()
+    const intervalId = setInterval(fetchServers, 10000)
+
+    return () => clearInterval(intervalId)
   }, [])
 
   if (loading) {

--- a/packages/database/drizzle/0001_curly_justin_hammer.sql
+++ b/packages/database/drizzle/0001_curly_justin_hammer.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "anomalies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"server_id" uuid NOT NULL,
+	"cpu_usage" real NOT NULL,
+	"type" text NOT NULL,
+	"timestamp" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "servers" ADD COLUMN "last_ping_at" timestamp;--> statement-breakpoint
+ALTER TABLE "anomalies" ADD CONSTRAINT "anomalies_server_id_servers_id_fk" FOREIGN KEY ("server_id") REFERENCES "public"."servers"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/database/drizzle/meta/0001_snapshot.json
+++ b/packages/database/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,125 @@
+{
+  "id": "6f4f968e-4bd0-43da-8035-ade5954f37e3",
+  "prevId": "3af12e46-f6a5-4b37-8054-6ab7110b4f89",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anomalies": {
+      "name": "anomalies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_usage": {
+          "name": "cpu_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anomalies_server_id_servers_id_fk": {
+          "name": "anomalies_server_id_servers_id_fk",
+          "tableFrom": "anomalies",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773170561657,
       "tag": "0000_spooky_butterfly",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1774045439118,
+      "tag": "0001_curly_justin_hammer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -4,6 +4,7 @@ export const servers = pgTable('servers', {
   id: uuid('id').defaultRandom().primaryKey(),
   name: text('name').notNull(),
   ipAddress: text('ip_address').notNull(),
+  lastPingAt: timestamp('last_ping_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 })
 


### PR DESCRIPTION
Updates the schema with lastPingAt, refactors GET /servers and POST /logs, and adds polling to the frontend. Closes #22.